### PR TITLE
Transition to the Tumblr API version 2 and authentication using OAuth 1.0a.

### DIFF
--- a/src/TumblThree/TumblThree.Applications/Controllers/ManagerController.cs
+++ b/src/TumblThree/TumblThree.Applications/Controllers/ManagerController.cs
@@ -20,7 +20,6 @@ using TumblThree.Applications.Properties;
 using TumblThree.Domain.Queue;
 using System.Windows;
 using System.Windows.Threading;
-using TumblThree.Applications;
 using System.Globalization;
 using System.Web.Script.Serialization;
 using System.Web;
@@ -514,7 +513,6 @@ namespace TumblThree.Applications.Controllers
             stopCommand.RaiseCanExecuteChanged();
         }
 
-
         private Task<bool> IsBlogOnline(string name)
         {
             return Task<bool>.Factory.StartNew(() =>
@@ -547,7 +545,7 @@ namespace TumblThree.Applications.Controllers
         {
             var parameters = new Dictionary<string, string>
             {
-              { "api_key", "fuiKNFp9vQFvjLNvx4sUwti4Yb5yGutBN4Xh10LXZhhRKjWlV4" },
+              { "api_key", shellService.Settings.ApiKey },
               { "reblog_info", "true" },
               { "limit", count.ToString() }
             };

--- a/src/TumblThree/TumblThree.Applications/Controllers/ManagerController.cs
+++ b/src/TumblThree/TumblThree.Applications/Controllers/ManagerController.cs
@@ -752,9 +752,9 @@ namespace TumblThree.Applications.Controllers
 
                                     if (shellService.Settings.DownloadImages == true)
                                     {
-                                        foreach (Datamodels.Post post in document.response.posts ?? new List<Datamodels.Post>())
+                                        foreach (Datamodels.Post post in document.response.posts.Where(posts => posts.type.Equals("photo")))
                                         {
-                                            foreach (DataModels.Photo photo in post.photos ?? new List<Datamodels.Photo>())
+                                            foreach (DataModels.Photo photo in post.photos)
                                             {
                                                 var imageUrl = photo.alt_sizes.ElementAt(shellService.Settings.ImageSizes.IndexOf(shellService.Settings.ImageSize.ToString())).url;
                                                 if (shellService.Settings.SkipGif == true && imageUrl.EndsWith(".gif"))
@@ -767,7 +767,7 @@ namespace TumblThree.Applications.Controllers
                                     }
                                     if (shellService.Settings.DownloadVideos == true)
                                     {
-                                        foreach (DataModels.Post post in document.response.posts ?? new List<Datamodels.Post>())
+                                        foreach (DataModels.Post post in document.response.posts.Where(posts => posts.type.Equals("video")))
                                         {
                                             if (shellService.Settings.VideoSize == 1080)
                                             {
@@ -799,7 +799,7 @@ namespace TumblThree.Applications.Controllers
 
                                     if (shellService.Settings.DownloadImages == true)
                                     {
-                                        foreach (Datamodels.Post post in document.response.posts.Where(posts => posts.tags.Any(tags.Contains)) ?? new List<Datamodels.Post>())
+                                        foreach (Datamodels.Post post in document.response.posts.Where(posts => posts.tags.Any(tag => tags.Equals(tag)) && posts.type.Equals("photo")))
                                         {
                                             foreach (DataModels.Photo photo in post.photos ?? new List<Datamodels.Photo>())
                                             {
@@ -814,7 +814,7 @@ namespace TumblThree.Applications.Controllers
                                     }
                                     if (shellService.Settings.DownloadVideos == true)
                                     {
-                                        foreach (DataModels.Post post in document.response.posts.Where(posts => posts.tags.Any(tags.Contains)) ?? new List<Datamodels.Post>())
+                                        foreach (DataModels.Post post in document.response.posts.Where(posts => posts.tags.Any(tag => tags.Equals(tag)) && posts.type.Equals("video")))
                                         {
                                             if (shellService.Settings.VideoSize == 1080)
                                             {

--- a/src/TumblThree/TumblThree.Applications/Controllers/ModuleController.cs
+++ b/src/TumblThree/TumblThree.Applications/Controllers/ModuleController.cs
@@ -60,6 +60,7 @@ namespace TumblThree.Applications.Controllers
             ShellService.ShowErrorAction = ShellViewModel.ShowError;
             ShellService.ShowDetailsViewAction = ShowDetailsView;
             ShellService.ShowQueueViewAction = ShowQueueView;
+            ShellService.InitializeOAuthManager();
 
             ManagerController.QueueManager = queueManager;
             ManagerController.Initialize();

--- a/src/TumblThree/TumblThree.Applications/DataModels/TumblrJson.cs
+++ b/src/TumblThree/TumblThree.Applications/DataModels/TumblrJson.cs
@@ -1,0 +1,168 @@
+﻿using System.Collections.Generic;
+
+namespace TumblThree.Applications.DataModels
+{
+    public class TumblrJson
+    {
+        public Meta meta { get; set; }
+        public Response response { get; set; }
+    }
+
+    public class Meta
+    {
+        public int status { get; set; }
+        public string msg { get; set; }
+    }
+
+    public class Response
+    {
+        public Blog blog { get; set; }
+        public List<Post> posts { get; set; }
+        public int total_posts { get; set; }
+    }
+
+    public class Blog
+    {
+        public string title { get; set; }
+        public string name { get; set; }
+        public int total_posts { get; set; }
+        public int posts { get; set; }
+        public string url { get; set; }
+        public int updated { get; set; }
+        public string description { get; set; }
+        public bool is_nsfw { get; set; }
+        public bool ask { get; set; }
+        public string ask_page_title { get; set; }
+        public bool ask_anon { get; set; }
+        public bool share_likes { get; set; }
+    }
+
+    public class Reblog
+    {
+        public string tree_html { get; set; }
+        public string comment { get; set; }
+    }
+
+    public class Theme
+    {
+        public string avatar_shape { get; set; }
+        public string background_color { get; set; }
+        public string body_font { get; set; }
+        public string header_bounds { get; set; }
+        public string header_image { get; set; }
+        public string header_image_focused { get; set; }
+        public string header_image_scaled { get; set; }
+        public bool header_stretch { get; set; }
+        public string link_color { get; set; }
+        public bool show_avatar { get; set; }
+        public bool show_description { get; set; }
+        public bool show_header_image { get; set; }
+        public bool show_title { get; set; }
+        public string title_color { get; set; }
+        public string title_font { get; set; }
+        public string title_font_weight { get; set; }
+    }
+
+    public class Blog2
+    {
+        public string name { get; set; }
+        public bool active { get; set; }
+        public Theme theme { get; set; }
+        public bool share_likes { get; set; }
+        public bool share_following { get; set; }
+        public bool can_be_followed { get; set; }
+    }
+
+    public class Post2
+    {
+        public string id { get; set; }
+    }
+
+    public class Trail
+    {
+        public Blog2 blog { get; set; }
+        public Post2 post { get; set; }
+        public string content_raw { get; set; }
+        public string content { get; set; }
+        public bool is_root_item { get; set; }
+    }
+
+    public class Player
+    {
+        public int width { get; set; }
+        public string embed_code { get; set; }
+    }
+
+    public class AltSize
+    {
+        public string url { get; set; }
+        public int width { get; set; }
+        public int height { get; set; }
+    }
+
+    public class OriginalSize
+    {
+        public string url { get; set; }
+        public int width { get; set; }
+        public int height { get; set; }
+    }
+
+    public class Photo
+    {
+        public string caption { get; set; }
+        public List<AltSize> alt_sizes { get; set; }
+        public OriginalSize original_size { get; set; }
+    }
+
+    public class Post
+    {
+        public string blog_name { get; set; }
+        public long id { get; set; }
+        public string post_url { get; set; }
+        public string slug { get; set; }
+        public string type { get; set; }
+        public string date { get; set; }
+        public int timestamp { get; set; }
+        public string state { get; set; }
+        public string format { get; set; }
+        public string reblog_key { get; set; }
+        public List<object> tags { get; set; }
+        public string short_url { get; set; }
+        public string summary { get; set; }
+        public object recommended_source { get; set; }
+        public object recommended_color { get; set; }
+        public List<object> highlighted { get; set; }
+        public int note_count { get; set; }
+        public object title { get; set; }
+        public string body { get; set; }
+        public List<Trail> trail { get; set; }
+        public string video_url { get; set; }
+        public bool html5_capable { get; set; }
+        public string thumbnail_url { get; set; }
+        public int thumbnail_width { get; set; }
+        public int thumbnail_height { get; set; }
+        public int duration { get; set; }
+        public List<Player> player { get; set; }
+        public string video_type { get; set; }
+        public string caption { get; set; }
+        public Reblog reblog { get; set; }
+        public string image_permalink { get; set; }
+        public List<Photo> photos { get; set; }
+        public string reblogged_from_id { get; set; }
+        public string reblogged_from_url { get; set; }
+        public string reblogged_from_name { get; set; }
+        public string reblogged_from_title { get; set; }
+        public string reblogged_from_uuid { get; set; }
+        public bool reblogged_from_can_message { get; set; }
+        public string reblogged_root_id { get; set; }
+        public string reblogged_root_url { get; set; }
+        public string reblogged_root_name { get; set; }
+        public string reblogged_root_title { get; set; }
+        public string reblogged_root_uuid { get; set; }
+        public bool reblogged_root_can_message { get; set; }
+        public bool can_like { get; set; }
+        public bool can_reblog { get; set; }
+        public bool can_send_in_message { get; set; }
+        public bool display_avatar { get; set; }
+    }
+}

--- a/src/TumblThree/TumblThree.Applications/DataModels/TumblrJson.cs
+++ b/src/TumblThree/TumblThree.Applications/DataModels/TumblrJson.cs
@@ -117,7 +117,7 @@ namespace TumblThree.Applications.DataModels
     public class Post
     {
         public string blog_name { get; set; }
-        public long id { get; set; }
+        public object id { get; set; }
         public string post_url { get; set; }
         public string slug { get; set; }
         public string type { get; set; }
@@ -141,7 +141,7 @@ namespace TumblThree.Applications.DataModels
         public string thumbnail_url { get; set; }
         public int thumbnail_width { get; set; }
         public int thumbnail_height { get; set; }
-        public int duration { get; set; }
+        public double duration { get; set; }
         public List<Player> player { get; set; }
         public string video_type { get; set; }
         public string caption { get; set; }
@@ -164,5 +164,7 @@ namespace TumblThree.Applications.DataModels
         public bool can_reblog { get; set; }
         public bool can_send_in_message { get; set; }
         public bool display_avatar { get; set; }
+        public string source_url { get; set; }
+        public string source_title { get; set; }
     }
 }

--- a/src/TumblThree/TumblThree.Applications/DataModels/TumblrPost.cs
+++ b/src/TumblThree/TumblThree.Applications/DataModels/TumblrPost.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TumblThree.Applications.DataModels
+{
+    public class TumblrPost
+    {
+        private Post post;
+        private TumblrJson json;
+        private long identification;
+        private string url;
+        private string shortUrl;
+        private string type;
+        private string date;
+        private DateTime isoDate;
+        private DateTime localDate;
+        private object title;
+        private List<object> tags;
+        private int noteCount;
+        private string sourceTitle;
+        private string sourceUrl;
+        private string fileName;
+        private string llink;
+
+        public TumblrPost(Post post)
+        {
+            this.title = String.Empty;
+            this.post = post;
+            this.identification = post.id;
+            this.url = post.post_url;
+            this.shortUrl = post.short_url;
+            this.type = post.type;
+            this.date = post.date;
+            this.isoDate = new System.DateTime(1970, 1, 1, 0, 0, 0, 0).AddSeconds((Convert.ToDouble(post.date)));
+            this.localDate = isoDate.ToLocalTime();
+            this.tags = post.tags;
+            this.noteCount = post.note_count;
+            this.sourceTitle = post.reblogged_root_title;
+            this.sourceUrl = post.reblogged_root_url;
+        }
+
+        private bool saveContent()
+        {
+            /// <summary>
+            /// parse the content of a TumblrPost
+            /// <para>the blog for the url</para>
+            /// </summary>
+            /// 
+            List<object> content = new List<object>();
+
+            if (type.Equals("photo"))
+            {
+                foreach (Photo photo in post.photos)
+                {
+                    //url = photo.original_size.url;
+                }
+            }
+
+            if (type.Equals("link"))
+            {
+
+            }
+
+            if (type.Equals("text"))
+            {
+                this.title = post.title.ToString();
+                content.Add(post.body);
+
+            }
+
+            if (type.Equals("quote"))
+            {
+
+            }
+
+            if (type.Equals("chat"))
+            {
+
+            }
+
+            if (type.Equals("answer"))
+            {
+
+            }
+
+            if (type.Equals("audio"))
+            {
+
+            }
+
+            if (type.Equals("video"))
+            {
+
+            }
+            return true;
+        }
+
+    }
+}

--- a/src/TumblThree/TumblThree.Applications/DataModels/TumblrPost.cs
+++ b/src/TumblThree/TumblThree.Applications/DataModels/TumblrPost.cs
@@ -10,7 +10,7 @@ namespace TumblThree.Applications.DataModels
     {
         private Post post;
         private TumblrJson json;
-        private long identification;
+        private object identification;
         private string url;
         private string shortUrl;
         private string type;

--- a/src/TumblThree/TumblThree.Applications/OAuth.cs
+++ b/src/TumblThree/TumblThree.Applications/OAuth.cs
@@ -315,7 +315,7 @@ namespace TumblThree.Applications
             {
                 if (!String.IsNullOrEmpty(item.Value) &&
                     !item.Key.EndsWith("secret"))
-                    sb.AppendFormat("oauth_{0}={1}&",
+                    sb.AppendFormat("oauth_{0}=\"{1}\", ",
                                     item.Key,
                                     UrlEncode(item.Value));
             }
@@ -369,10 +369,10 @@ namespace TumblThree.Applications
         public OAuthResponse AcquireRequestToken(string uri, string method)
         {
             NewRequest();
-            var authzHeader = GetAuthorizationHeader(uri, method);
+            var authHeader = GetAuthorizationHeader(uri, method);
             // prepare the token request
-            var request = (System.Net.HttpWebRequest)System.Net.WebRequest.Create(uri + "?" + authzHeader);
-            //request.Headers.Add("Authorization", authzHeader);
+            var request = (System.Net.HttpWebRequest)System.Net.WebRequest.Create(uri);
+            request.Headers.Add("Authorization", authHeader);
             request.Method = method;
 
             using (var response = (System.Net.HttpWebResponse)request.GetResponse())
@@ -438,11 +438,11 @@ namespace TumblThree.Applications
             NewRequest();
             _params["verifier"] = pin;
 
-            var authzHeader = GetAuthorizationHeader(uri, method);
+            var authHeader = GetAuthorizationHeader(uri, method);
 
             // prepare the token request
-            var request = (System.Net.HttpWebRequest)System.Net.WebRequest.Create(uri + "?" + authzHeader);
-            //request.Headers.Add("Authorization", authzHeader);
+            var request = (System.Net.HttpWebRequest)System.Net.WebRequest.Create(uri);
+            request.Headers.Add("Authorization", authHeader);
             request.Method = method;
 
             using (var response = (System.Net.HttpWebResponse)request.GetResponse())
@@ -476,12 +476,12 @@ namespace TumblThree.Applications
         ///   </para>
         /// </remarks>
         ///
-        /// <seealso cref='GenerateAuthzHeader'>
+        /// <seealso cref='GenerateauthHeader'>
         public string GenerateCredsHeader(string uri, string method, string realm)
         {
             NewRequest();
-            var authzHeader = GetAuthorizationHeader(uri, method, realm);
-            return authzHeader;
+            var authHeader = GetAuthorizationHeader(uri, method, realm);
+            return authHeader;
         }
 
         /// <summary>
@@ -499,12 +499,12 @@ namespace TumblThree.Applications
         ///   </para>
         /// </remarks>
         ///
-        /// <seealso cref='GenerateAuthzHeader'>
-        public string GenerateAuthzHeader(string uri, string method)
+        /// <seealso cref='GenerateauthHeader'>
+        public string GenerateauthHeader(string uri, string method)
         {
             NewRequest();
-            var authzHeader = GetAuthorizationHeader(uri, method, null);
-            return authzHeader;
+            var authHeader = GetAuthorizationHeader(uri, method, null);
+            return authHeader;
         }
 
         private string GetAuthorizationHeader(string uri, string method)
@@ -524,7 +524,7 @@ namespace TumblThree.Applications
 
             var erp = EncodeRequestParameters(this._params);
             return (String.IsNullOrEmpty(realm))
-                ? erp
+                ? "OAuth " + erp
                 : String.Format("OAuth realm=\"{0}\", ", realm) + erp;
         }
 

--- a/src/TumblThree/TumblThree.Applications/OAuth.cs
+++ b/src/TumblThree/TumblThree.Applications/OAuth.cs
@@ -470,33 +470,6 @@ namespace TumblThree.Applications
         ///     appropriate form, including the oauth_signature value, and
         ///     returns the result.
         ///   </para>
-        ///   <para>
-        ///     If you pass in a non-null, non-empty realm, this method will
-        ///     include the realm='foo' clause in the Authorization header.
-        ///   </para>
-        /// </remarks>
-        ///
-        /// <seealso cref='GenerateauthHeader'>
-        public string GenerateCredsHeader(string uri, string method, string realm)
-        {
-            NewRequest();
-            var authHeader = GetAuthorizationHeader(uri, method, realm);
-            return authHeader;
-        }
-
-        /// <summary>
-        ///   Generate a string to be used in an Authorization header in
-        ///   an HTTP request.
-        /// </summary>
-        /// <remarks>
-        ///   <para>
-        ///     This method assembles the available oauth_ parameters that
-        ///     have been set in the Dictionary in this instance, produces
-        ///     the signature base (As described by the OAuth spec, RFC 5849),
-        ///     signs it, then re-formats the oauth_ parameters into the
-        ///     appropriate form, including the oauth_signature value, and
-        ///     returns the result.
-        ///   </para>
         /// </remarks>
         ///
         /// <seealso cref='GenerateauthHeader'>

--- a/src/TumblThree/TumblThree.Applications/OAuth.cs
+++ b/src/TumblThree/TumblThree.Applications/OAuth.cs
@@ -441,8 +441,8 @@ namespace TumblThree.Applications
             var authzHeader = GetAuthorizationHeader(uri, method);
 
             // prepare the token request
-            var request = (System.Net.HttpWebRequest)System.Net.WebRequest.Create(uri);
-            request.Headers.Add("Authorization", authzHeader);
+            var request = (System.Net.HttpWebRequest)System.Net.WebRequest.Create(uri + "?" + authzHeader);
+            //request.Headers.Add("Authorization", authzHeader);
             request.Method = method;
 
             using (var response = (System.Net.HttpWebResponse)request.GetResponse())

--- a/src/TumblThree/TumblThree.Applications/OAuth.cs
+++ b/src/TumblThree/TumblThree.Applications/OAuth.cs
@@ -1,0 +1,648 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+
+namespace TumblThree.Applications
+{
+    /// <summary>
+    ///   A class to manage OAuth interactions.  This works with
+    ///   Twitter, not sure about other OAuth-enabled services.
+    /// </summary>
+    /// <remarks>
+    ///   <para>
+    ///     This class holds the relevant oauth parameters, and exposes
+    ///     methods that do things, based on those params.
+    ///   </para>
+    ///   <para>
+    ///     See http://dev.twitpic.com/docs/2/upload/ for an example of the
+    ///     oauth parameters.  The params include token, consumer_key,
+    ///     timestamp, version, and so on.  In the actual HTTP message, they
+    ///     all include the oauth_ prefix, so ..  oauth_token,
+    ///     oauth_timestamp, and so on.  You set these via a string indexer.
+    ///     If the instance of the class is called oauth, then to set
+    ///     the oauth_token parameter, you use oath["token"] in C#.
+    ///   </para>
+    ///   <para>
+    ///     This class automatically sets many of the required oauth parameters;
+    ///     this includes the timestamp, nonce, callback, and version parameters.
+    ///     (The callback param is initialized to 'oob'). You can reset any of
+    ///     these parameters as you see fit.  In many cases you won't have to.
+    ///   </para>
+    ///   <para>
+    ///     The public methods on the class include:
+    ///     AcquireRequestToken, AcquireAccessToken,
+    ///     GenerateCredsHeader, and GenerateAuthorizationHeader.  The
+    ///     first two are used only on the first run of an applicaiton,
+    ///     or after a user has explicitly de-authorized an application
+    ///     for use with OAuth.  Normally, the GenerateXxxHeader methods
+    ///     can be used repeatedly, when sending HTTP messages that
+    ///     require an OAuth Authorization header.
+    ///   </para>
+    ///   <para>
+    ///     The AcquireRequestToken and AcquireAccessToken methods
+    ///     actually send out HTTP messages.
+    ///   </para>
+    ///   <para>
+    ///     The GenerateXxxxHeaders are used when constructing and
+    ///     sending your own HTTP messages.
+    ///   </para>
+    /// </remarks>
+    public class OAuthManager
+    {
+        private static readonly DateTime _epoch = new DateTime(1970, 1, 1, 0, 0, 0, 0);
+        private Dictionary<String, String> _params;
+        private Random _random;
+        /// <summary>
+        ///   The default public constructor.
+        /// </summary>
+        /// <remarks>
+        ///   <para>
+        ///     Initializes various fields to default values.
+        ///   </para>
+        /// </remarks>
+        public OAuthManager()
+        {
+            _random = new Random();
+            _params = new Dictionary<String, String>();
+            _params["consumer_key"] = "";
+            _params["consumer_secret"] = "";
+            _params["timestamp"] = GenerateTimeStamp();
+            _params["nonce"] = GenerateNonce();
+            _params["signature_method"] = "HMAC-SHA1";
+            _params["signature"] = "";
+            _params["token"] = "";
+            _params["token_secret"] = "";
+            _params["version"] = "1.0";
+        }
+
+        /// <summary>
+        ///   The constructor to use when using OAuth when you already
+        ///   have an OAuth access token.
+        /// </summary>
+        /// <remarks>
+        ///   <para>
+        ///     The parameters for this constructor all have the
+        ///     meaning you would expect.  The token and tokenSecret
+        ///     are set in oauth_token, and oauth_token_secret.
+        ///     These are *Access* tokens, obtained after a call
+        ///     to AcquireAccessToken.  The application can store
+        ///     those tokens and re-use them on successive runs.
+        ///     For twitter at least, the access tokens never expire.
+        ///   </para>
+        /// </remarks>
+        public OAuthManager(string consumerKey,
+                       string consumerSecret,
+                       string token,
+                       string tokenSecret) : this()
+
+        {
+            _params["consumer_key"] = consumerKey;
+            _params["consumer_secret"] = consumerSecret;
+            _params["token"] = token;
+            _params["token_secret"] = tokenSecret;
+        }
+
+        /// <summary>
+        ///   string indexer to get or set oauth parameter values.
+        /// </summary>
+        /// <remarks>
+        ///   <para>
+        ///     Use the parameter name *without* the oauth_ prefix.
+        ///     If you want to set the value for the oauth_token parameter
+        ///     field in an HTTP message, then use oauth["token"].
+        ///   </para>
+        ///   <para>
+        ///     The set of oauth param names known by this indexer includes:
+        ///     callback, consumer_key, consumer_secret, timestamp, nonce,
+        ///     signature_method, signature, token, token_secret, and version.
+        ///   </para>
+        ///   <para>
+        ///     If you try setting a parameter with a name that is not known,
+        ///     the setter will throw.  You cannot add new oauth parameters
+        ///     using the setter on this indexer.
+        ///   </para>
+        /// </remarks>
+        public string this[string ix]
+        {
+            get
+            {
+                if (_params.ContainsKey(ix))
+                    return _params[ix];
+                throw new ArgumentException(ix);
+            }
+            set
+            {
+                if (!_params.ContainsKey(ix))
+                    throw new ArgumentException(ix);
+                _params[ix] = value;
+            }
+        }
+
+        /// <summary>
+        /// Generate the timestamp for the signature.
+        /// </summary>
+        /// <returns>The timestamp, in string form.</returns>
+        private string GenerateTimeStamp()
+        {
+            TimeSpan ts = DateTime.UtcNow - _epoch;
+            return Convert.ToInt64(ts.TotalSeconds).ToString();
+        }
+
+        /// <summary>
+        ///   Renews the nonce and timestamp on the oauth parameters.
+        /// </summary>
+        /// <remarks>
+        ///   <para>
+        ///     Each new request should get a new, current timestamp, and a
+        ///     nonce. This helper method does both of those things. This gets
+        ///     called before generating an authorization header, as for example
+        ///     when the user of this class calls <see cref='AcquireRequestToken'>.
+        ///   </para>
+        /// </remarks>
+        private void NewRequest()
+        {
+            _params["nonce"] = GenerateNonce();
+            _params["timestamp"] = GenerateTimeStamp();
+        }
+
+        /// <summary>
+        /// Generate an oauth nonce.
+        /// </summary>
+        /// <remarks>
+        ///   <para>
+        ///     According to RFC 5849, A nonce is a random string,
+        ///     uniquely generated by the client to allow the server to
+        ///     verify that a request has never been made before and
+        ///     helps prevent replay attacks when requests are made over
+        ///     a non-secure channel.  The nonce value MUST be unique
+        ///     across all requests with the same timestamp, client
+        ///     credentials, and token combinations.
+        ///   </para>
+        ///   <para>
+        ///     One way to implement the nonce is just to use a
+        ///     monotonically-increasing integer value.  It starts at zero and
+        ///     increases by 1 for each new request or signature generated.
+        ///     Keep in mind the nonce needs to be unique only for a given
+        ///     timestamp!  So if your app makes less than one request per
+        ///     second, then using a static nonce of "0" will work.
+        ///   </para>
+        ///   <para>
+        ///     Most oauth nonce generation routines are waaaaay over-engineered,
+        ///     and this one is no exception.
+        ///   </para>
+        /// </remarks>
+        /// <returns>the nonce</returns>
+        private string GenerateNonce()
+        {
+            var sb = new System.Text.StringBuilder();
+            for (int i = 0; i < 8; i++)
+            {
+                int g = _random.Next(3);
+                switch (g)
+                {
+                    case 0:
+                        // lowercase alpha
+                        sb.Append((char)(_random.Next(26) + 97), 1);
+                        break;
+                    default:
+                        // numeric digits
+                        sb.Append((char)(_random.Next(10) + 48), 1);
+                        break;
+                }
+            }
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Internal function to extract from a URL all query string
+        /// parameters that are not related to oauth - in other words all
+        /// parameters not begining with "oauth_".
+        /// </summary>
+        ///
+        /// <remarks>
+        ///   <para>
+        ///     For example, given a url like http://foo?a=7&guff, the
+        ///     returned value will be a Dictionary of string-to-string
+        ///     relations.  There will be 2 entries in the Dictionary: "a"=>7,
+        ///     and "guff"=>"".
+        ///   </para>
+        /// </remarks>
+        ///
+        /// <param name="queryString">The query string part of the Url</param>
+        ///
+        /// <returns>A Dictionary containing the set of
+        /// parameter names and associated values</returns>
+        private Dictionary<String, String> ExtractQueryParameters(string queryString)
+        {
+            if (queryString.StartsWith("?"))
+                queryString = queryString.Remove(0, 1);
+
+            var result = new Dictionary<String, String>();
+
+            if (string.IsNullOrEmpty(queryString))
+                return result;
+
+            foreach (string s in queryString.Split('&'))
+            {
+                if (!string.IsNullOrEmpty(s) && !s.StartsWith("oauth_"))
+                {
+                    if (s.IndexOf('=') > -1)
+                    {
+                        string[] temp = s.Split('=');
+                        result.Add(temp[0], temp[1]);
+                    }
+                    else
+                        result.Add(s, string.Empty);
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        ///   This is an oauth-compliant Url Encoder.  The default .NET
+        ///   encoder outputs the percent encoding in lower case.  While this
+        ///   is not a problem with the percent encoding defined in RFC 3986,
+        ///   OAuth (RFC 5849) requires that the characters be upper case
+        ///   throughout OAuth.
+        /// </summary>
+        ///
+        /// <param name="value">The value to encode</param>
+        ///
+        /// <returns>the Url-encoded version of that string</returns>
+        public static string UrlEncode(string value)
+        {
+            var result = new System.Text.StringBuilder();
+            foreach (char symbol in value)
+            {
+                if (unreservedChars.IndexOf(symbol) != -1)
+                    result.Append(symbol);
+                else
+                    result.Append('%' + String.Format("{0:X2}", (int)symbol));
+            }
+            return result.ToString();
+        }
+        private static string unreservedChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.~";
+
+        /// <summary>
+        /// Formats the list of request parameters into string a according
+        /// to the requirements of oauth. The resulting string could be used
+        /// in the Authorization header of the request.
+        /// </summary>
+        ///
+        /// <remarks>
+        ///   <para>
+        ///     See http://dev.twitter.com/pages/auth#intro  for some
+        ///     background.  The output of this is not suitable for signing.
+        ///   </para>
+        ///   <para>
+        ///     There are 2 formats for specifying the list of oauth
+        ///     parameters in the oauth spec: one suitable for signing, and
+        ///     the other suitable for use within Authorization HTTP Headers.
+        ///     This method emits a string suitable for the latter.
+        ///   </para>
+        /// </remarks>
+        ///
+        /// <param name="parameters">The Dictionary of
+        /// parameters. It need not be sorted.</param>
+        ///
+        /// <returns>a string representing the parameters</returns>
+        private static string EncodeRequestParameters(ICollection<KeyValuePair<String, String>> p)
+        {
+            var sb = new System.Text.StringBuilder();
+            foreach (KeyValuePair<String, String> item in p.OrderBy(x => x.Key))
+            {
+                if (!String.IsNullOrEmpty(item.Value) &&
+                    !item.Key.EndsWith("secret"))
+                    sb.AppendFormat("oauth_{0}={1}&",
+                                    item.Key,
+                                    UrlEncode(item.Value));
+            }
+
+            return sb.ToString().TrimEnd(' ').TrimEnd(',');
+        }
+
+        /// <summary>
+        ///   Acquire a request token, from the given URI, using the given
+        ///   HTTP method.
+        /// </summary>
+        ///
+        /// <remarks>
+        ///   <para>
+        ///     To use this method, first instantiate a new Oauth.OAuthManager object,
+        ///     then set the callback param (oauth["callback"]='oob'). After the
+        ///     call returns, you should direct the user to open a browser window
+        ///     to the authorization page for the OAuth-enabled service. Or,
+        ///     you can automatically open that page yourself. Do this with
+        ///     System.Diagnostics.Process.Start(), passing the URL of the page.
+        ///     There should be one query param: oauth_token with the value
+        ///     obtained from oauth["token"].
+        ///   </para>
+        ///   <para>
+        ///     According to the OAuth spec, you need to do this only ONCE per
+        ///     application.  In other words, the first time the application
+        ///     is run.  The normal oauth workflow is:  (1) get a request token,
+        ///     (2) use that to acquire an access token (which requires explicit
+        ///     user approval), then (3) using that access token, invoke
+        ///     protected services.  The first two steps need to be done only
+        ///     once per application.
+        ///   </para>
+        ///   <para>
+        ///     For Twitter, at least, you can cache the access tokens
+        ///     indefinitely; Twitter says they never expire.  However, other
+        ///     oauth services may not do the same. Also: the user may at any
+        ///     time revoke his authorization for your app, in which case you
+        ///     need to perform the first 2 steps again.
+        ///   </para>
+        /// </remarks>
+        ///
+        /// <seealso cref='AcquireAccessToken'>
+        ///
+        /// </example>
+        /// <returns>
+        ///   a response object that contains the entire text of the response,
+        ///   as well as extracted parameters. This method presumes the
+        ///   response is query-param encoded. In other words,
+        ///   poauth_token=foo&something_else=bar.
+        /// </returns>
+        public OAuthResponse AcquireRequestToken(string uri, string method)
+        {
+            NewRequest();
+            var authzHeader = GetAuthorizationHeader(uri, method);
+            // prepare the token request
+            var request = (System.Net.HttpWebRequest)System.Net.WebRequest.Create(uri + "?" + authzHeader);
+            //request.Headers.Add("Authorization", authzHeader);
+            request.Method = method;
+
+            using (var response = (System.Net.HttpWebResponse)request.GetResponse())
+            {
+                using (var reader = new System.IO.StreamReader(response.GetResponseStream()))
+                {
+                    var r = new OAuthResponse(reader.ReadToEnd());
+                    this["token"] = r["oauth_token"];
+
+                    // Sometimes the request_token URL gives us an access token,
+                    // with no user interaction required. Eg, when prior approval
+                    // has already been granted.
+                    try
+                    {
+                        if (r["oauth_token_secret"] != null)
+                            this["token_secret"] = r["oauth_token_secret"];
+                    }
+                    catch { }
+                    return r;
+                }
+            }
+        }
+
+        /// <summary>
+        ///   Acquire an access token, from the given URI, using the given
+        ///   HTTP method.
+        /// </summary>
+        ///
+        /// <remarks>
+        ///   <para>
+        ///     To use this method, you must first set the oauth_token to the value
+        ///     of the request token.  Eg, oauth["token"] = "whatever".
+        ///   </para>
+        ///   <para>
+        ///     According to the OAuth spec, you need to do this only ONCE per
+        ///     application.  In other words, the first time the application
+        ///     is run.  The normal oauth workflow is:  (1) get a request token,
+        ///     (2) use that to acquire an access token (which requires explicit
+        ///     user approval), then (3) using that access token, invoke
+        ///     protected services.  The first two steps need to be done only
+        ///     once per application.
+        ///   </para>
+        ///   <para>
+        ///     For Twitter, at least, you can cache the access tokens
+        ///     indefinitely; Twitter says they never expire.  However, other
+        ///     oauth services may not do the same. Also: the user may at any
+        ///     time revoke his authorization for your app, in which case you
+        ///     need to perform the first 2 steps again.
+        ///   </para>
+        /// </remarks>
+        ///
+        /// <seealso cref='AcquireRequestToken'>
+        ///
+        /// </example>
+        /// <returns>
+        ///   a response object that contains the entire text of the response,
+        ///   as well as extracted parameters. This method presumes the
+        ///   response is query-param encoded. In other words,
+        ///   poauth_token=foo&something_else=bar.
+        /// </returns>
+        public OAuthResponse AcquireAccessToken(string uri, string method, string pin)
+        {
+            NewRequest();
+            _params["verifier"] = pin;
+
+            var authzHeader = GetAuthorizationHeader(uri, method);
+
+            // prepare the token request
+            var request = (System.Net.HttpWebRequest)System.Net.WebRequest.Create(uri);
+            request.Headers.Add("Authorization", authzHeader);
+            request.Method = method;
+
+            using (var response = (System.Net.HttpWebResponse)request.GetResponse())
+            {
+                using (var reader = new System.IO.StreamReader(response.GetResponseStream()))
+                {
+                    var r = new OAuthResponse(reader.ReadToEnd());
+                    this["token"] = r["oauth_token"];
+                    this["token_secret"] = r["oauth_token_secret"];
+                    return r;
+                }
+            }
+        }
+
+        /// <summary>
+        ///   Generate a string to be used in an Authorization header in
+        ///   an HTTP request.
+        /// </summary>
+        /// <remarks>
+        ///   <para>
+        ///     This method assembles the available oauth_ parameters that
+        ///     have been set in the Dictionary in this instance, produces
+        ///     the signature base (As described by the OAuth spec, RFC 5849),
+        ///     signs it, then re-formats the oauth_ parameters into the
+        ///     appropriate form, including the oauth_signature value, and
+        ///     returns the result.
+        ///   </para>
+        ///   <para>
+        ///     If you pass in a non-null, non-empty realm, this method will
+        ///     include the realm='foo' clause in the Authorization header.
+        ///   </para>
+        /// </remarks>
+        ///
+        /// <seealso cref='GenerateAuthzHeader'>
+        public string GenerateCredsHeader(string uri, string method, string realm)
+        {
+            NewRequest();
+            var authzHeader = GetAuthorizationHeader(uri, method, realm);
+            return authzHeader;
+        }
+
+        /// <summary>
+        ///   Generate a string to be used in an Authorization header in
+        ///   an HTTP request.
+        /// </summary>
+        /// <remarks>
+        ///   <para>
+        ///     This method assembles the available oauth_ parameters that
+        ///     have been set in the Dictionary in this instance, produces
+        ///     the signature base (As described by the OAuth spec, RFC 5849),
+        ///     signs it, then re-formats the oauth_ parameters into the
+        ///     appropriate form, including the oauth_signature value, and
+        ///     returns the result.
+        ///   </para>
+        /// </remarks>
+        ///
+        /// <seealso cref='GenerateAuthzHeader'>
+        public string GenerateAuthzHeader(string uri, string method)
+        {
+            NewRequest();
+            var authzHeader = GetAuthorizationHeader(uri, method, null);
+            return authzHeader;
+        }
+
+        private string GetAuthorizationHeader(string uri, string method)
+        {
+            return GetAuthorizationHeader(uri, method, null);
+        }
+
+        private string GetAuthorizationHeader(string uri, string method, string realm)
+        {
+            if (string.IsNullOrEmpty(this._params["consumer_key"]))
+                throw new ArgumentNullException("consumer_key");
+
+            if (string.IsNullOrEmpty(this._params["signature_method"]))
+                throw new ArgumentNullException("signature_method");
+
+            Sign(uri, method);
+
+            var erp = EncodeRequestParameters(this._params);
+            return (String.IsNullOrEmpty(realm))
+                ? erp
+                : String.Format("OAuth realm=\"{0}\", ", realm) + erp;
+        }
+
+        private void Sign(string uri, string method)
+        {
+            var signatureBase = GetSignatureBase(uri, method);
+            var hash = GetHash();
+
+            byte[] dataBuffer = System.Text.Encoding.ASCII.GetBytes(signatureBase);
+            byte[] hashBytes = hash.ComputeHash(dataBuffer);
+
+            this["signature"] = Convert.ToBase64String(hashBytes);
+        }
+
+        /// <summary>
+        /// Formats the list of request parameters into "signature base" string as
+        /// defined by RFC 5849.  This will then be MAC'd with a suitable hash.
+        /// </summary>
+        private string GetSignatureBase(string url, string method)
+        {
+            // normalize the URI
+            var uri = new Uri(url);
+            var normUrl = string.Format("{0}://{1}", uri.Scheme, uri.Host);
+            if (!((uri.Scheme == "http" && uri.Port == 80) ||
+                  (uri.Scheme == "https" && uri.Port == 443)))
+                normUrl += ":" + uri.Port;
+
+            normUrl += uri.AbsolutePath;
+
+            // the sigbase starts with the method and the encoded URI
+            var sb = new System.Text.StringBuilder();
+            sb.Append(method)
+                .Append('&')
+                .Append(UrlEncode(normUrl))
+                .Append('&');
+
+            // the parameters follow - all oauth params plus any params on
+            // the uri
+            // each uri may have a distinct set of query params
+            var p = ExtractQueryParameters(uri.Query);
+            // add all non-empty params to the "current" params
+            foreach (var p1 in this._params)
+            {
+                // Exclude all oauth params that are secret or
+                // signatures; any secrets should be kept to ourselves,
+                // and any existing signature will be invalid.
+                if (!String.IsNullOrEmpty(this._params[p1.Key]) &&
+                    !p1.Key.EndsWith("_secret") &&
+                    !p1.Key.EndsWith("signature"))
+                    p.Add("oauth_" + p1.Key, p1.Value);
+            }
+
+            // concat+format all those params
+            var sb1 = new System.Text.StringBuilder();
+            foreach (KeyValuePair<String, String> item in p.OrderBy(x => x.Key))
+            {
+                // even "empty" params need to be encoded this way.
+                sb1.AppendFormat("{0}={1}&", item.Key, item.Value);
+            }
+
+            // append the UrlEncoded version of that string to the sigbase
+            sb.Append(UrlEncode(sb1.ToString().TrimEnd('&')));
+            var result = sb.ToString();
+            return result;
+        }
+
+        private HashAlgorithm GetHash()
+        {
+            if (this["signature_method"] != "HMAC-SHA1")
+                throw new NotImplementedException();
+
+            string keystring = string.Format("{0}&{1}",
+                                             UrlEncode(this["consumer_secret"]),
+                                             UrlEncode(this["token_secret"]));
+            var hmacsha1 = new HMACSHA1
+            {
+                Key = System.Text.Encoding.ASCII.GetBytes(keystring)
+            };
+            return hmacsha1;
+        }
+    }
+
+    /// <summary>
+    ///   A class to hold an OAuth response message.
+    /// </summary>
+    public class OAuthResponse
+    {
+        /// <summary>
+        ///   All of the text in the response. This is useful if the app wants
+        ///   to do its own parsing.
+        /// </summary>
+        public string AllText { get; set; }
+        private Dictionary<String, String> _params;
+
+        /// <summary>
+        ///   a Dictionary of response parameters.
+        /// </summary>
+        public string this[string ix]
+        {
+            get
+            {
+                return _params[ix];
+            }
+        }
+
+
+        public OAuthResponse(string alltext)
+        {
+            AllText = alltext;
+            _params = new Dictionary<String, String>();
+            var kvpairs = alltext.Split('&');
+            foreach (var pair in kvpairs)
+            {
+                var kv = pair.Split('=');
+                _params.Add(kv[0], kv[1]);
+            }
+            // expected keys:
+            //   oauth_token, oauth_token_secret, user_id, screen_name, etc
+        }
+    }
+}

--- a/src/TumblThree/TumblThree.Applications/Properties/AppSettings.cs
+++ b/src/TumblThree/TumblThree.Applications/Properties/AppSettings.cs
@@ -31,6 +31,9 @@ namespace TumblThree.Applications.Properties
         public string OAuthCallback { get; set; }
 
         [DataMember]
+        public string AccessToken { get; set; }
+
+        [DataMember]
         public double Left { get; set; }
 
         [DataMember]
@@ -106,7 +109,8 @@ namespace TumblThree.Applications.Properties
 
             OAuthCallback = @"http://www.tumblr.com/tumblthree";
             ApiKey = "lICmmi2UfTdai1aVEfrMMoKidUfIMDV1pXlfiVdqhLmQgTNI9D";
-            SecretKey = "BB2JvuS0";
+            SecretKey = "BB2p9fa0";
+            AccessToken = string.Empty;
             Left = 50;
             Top = 50;
             Height = 800;

--- a/src/TumblThree/TumblThree.Applications/Properties/AppSettings.cs
+++ b/src/TumblThree/TumblThree.Applications/Properties/AppSettings.cs
@@ -22,16 +22,28 @@ namespace TumblThree.Applications.Properties
         };
 
         [DataMember]
+        public string RequestTokenUrl { get; set; }
+
+        [DataMember]
+        public string AuthorizeUrl { get; set; }
+
+        [DataMember]
+        public string AccessTokenUrl { get; set; }
+
+        [DataMember]
+        public string OAuthCallbackUrl { get; set; }
+
+        [DataMember]
         public string ApiKey { get; set; }
 
         [DataMember]
         public string SecretKey { get; set; }
 
         [DataMember]
-        public string OAuthCallback { get; set; }
+        public string OAuthToken { get; set; }
 
         [DataMember]
-        public string AccessToken { get; set; }
+        public string OAuthTokenSecret { get; set; }
 
         [DataMember]
         public double Left { get; set; }
@@ -106,11 +118,14 @@ namespace TumblThree.Applications.Properties
 
         private void Initialize()
         {
-
-            OAuthCallback = @"http://www.tumblr.com/tumblthree";
+            RequestTokenUrl = @"https://www.tumblr.com/oauth/request_token";
+            AuthorizeUrl = @"https://www.tumblr.com/oauth/authorize";
+            AccessTokenUrl = @"https://www.tumblr.com/oauth/access_token";
+            OAuthCallbackUrl = @"http://www.tumblr.com/tumblthree";
             ApiKey = "lICmmi2UfTdai1aVEfrMMoKidUfIMDV1pXlfiVdqhLmQgTNI9D";
-            SecretKey = "BB2p9fa0";
-            AccessToken = string.Empty;
+            SecretKey = "BB2Jvk69MMfa0";
+            OAuthToken = string.Empty;
+            OAuthTokenSecret = string.Empty;
             Left = 50;
             Top = 50;
             Height = 800;

--- a/src/TumblThree/TumblThree.Applications/Properties/AppSettings.cs
+++ b/src/TumblThree/TumblThree.Applications/Properties/AppSettings.cs
@@ -121,9 +121,9 @@ namespace TumblThree.Applications.Properties
             RequestTokenUrl = @"https://www.tumblr.com/oauth/request_token";
             AuthorizeUrl = @"https://www.tumblr.com/oauth/authorize";
             AccessTokenUrl = @"https://www.tumblr.com/oauth/access_token";
-            OAuthCallbackUrl = @"http://www.tumblr.com/tumblthree";
+            OAuthCallbackUrl = @"https://github.com/johanneszab/TumblThree";
             ApiKey = "lICmmi2UfTdai1aVEfrMMoKidUfIMDV1pXlfiVdqhLmQgTNI9D";
-            SecretKey = "BB2Jvk69MMfa0";
+            SecretKey = "BB2Jfa0";
             OAuthToken = string.Empty;
             OAuthTokenSecret = string.Empty;
             Left = 50;

--- a/src/TumblThree/TumblThree.Applications/Properties/AppSettings.cs
+++ b/src/TumblThree/TumblThree.Applications/Properties/AppSettings.cs
@@ -121,9 +121,9 @@ namespace TumblThree.Applications.Properties
             RequestTokenUrl = @"https://www.tumblr.com/oauth/request_token";
             AuthorizeUrl = @"https://www.tumblr.com/oauth/authorize";
             AccessTokenUrl = @"https://www.tumblr.com/oauth/access_token";
-            OAuthCallbackUrl = @"https://github.com/johanneszab/TumblThree";
+            OAuthCallbackUrl = @"http://www.tumblr.com/tumblthree";
             ApiKey = "lICmmi2UfTdai1aVEfrMMoKidUfIMDV1pXlfiVdqhLmQgTNI9D";
-            SecretKey = "BB2Jfa0";
+            SecretKey = "BB2JMMfa0";
             OAuthToken = string.Empty;
             OAuthTokenSecret = string.Empty;
             Left = 50;

--- a/src/TumblThree/TumblThree.Applications/Properties/AppSettings.cs
+++ b/src/TumblThree/TumblThree.Applications/Properties/AppSettings.cs
@@ -22,6 +22,15 @@ namespace TumblThree.Applications.Properties
         };
 
         [DataMember]
+        public string ApiKey { get; set; }
+
+        [DataMember]
+        public string SecretKey { get; set; }
+
+        [DataMember]
+        public string OAuthCallback { get; set; }
+
+        [DataMember]
         public double Left { get; set; }
 
         [DataMember]
@@ -94,6 +103,10 @@ namespace TumblThree.Applications.Properties
 
         private void Initialize()
         {
+
+            OAuthCallback = @"http://www.tumblr.com/tumblthree";
+            ApiKey = "lICmmi2UfTdai1aVEfrMMoKidUfIMDV1pXlfiVdqhLmQgTNI9D";
+            SecretKey = "BB2JvuS0";
             Left = 50;
             Top = 50;
             Height = 800;

--- a/src/TumblThree/TumblThree.Applications/Properties/Resources.Designer.cs
+++ b/src/TumblThree/TumblThree.Applications/Properties/Resources.Designer.cs
@@ -151,6 +151,15 @@ namespace TumblThree.Applications.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Could not initialize the OAuth Manager.
+        /// </summary>
+        public static string CouldNotStartOAuthManager {
+            get {
+                return ResourceManager.GetString("CouldNotStartOAuthManager", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The Crawler Thread encountered an error..
         /// </summary>
         public static string CrawlerError {

--- a/src/TumblThree/TumblThree.Applications/Properties/Resources.de.resx
+++ b/src/TumblThree/TumblThree.Applications/Properties/Resources.de.resx
@@ -147,6 +147,9 @@
   <data name="CouldNotSaveQueueList" xml:space="preserve">
     <value>Die Downloadliste konnte nicht gespeichert werden.</value>
   </data>
+  <data name="CouldNotStartOAuthManager" xml:space="preserve">
+    <value>Der OAuthManager konnte nicht gestartet werden.</value>
+  </data>
   <data name="CrawlerError" xml:space="preserve">
     <value>Im Crawlerprozess ist ein Problem aufgetreten.</value>
   </data>

--- a/src/TumblThree/TumblThree.Applications/Properties/Resources.resx
+++ b/src/TumblThree/TumblThree.Applications/Properties/Resources.resx
@@ -147,6 +147,9 @@
   <data name="CouldNotSaveQueueList" xml:space="preserve">
     <value>The queuelist could not be saved.</value>
   </data>
+  <data name="CouldNotStartOAuthManager" xml:space="preserve">
+    <value>Could not initialize the OAuth Manager</value>
+  </data>
   <data name="CrawlerError" xml:space="preserve">
     <value>The Crawler Thread encountered an error.</value>
   </data>

--- a/src/TumblThree/TumblThree.Applications/Services/IShellService.cs
+++ b/src/TumblThree/TumblThree.Applications/Services/IShellService.cs
@@ -36,5 +36,7 @@ namespace TumblThree.Applications.Services
         void AddTaskToCompleteBeforeShutdown(Task task);
 
         IDisposable SetApplicationBusy();
+
+        OAuthManager OAuthManager { get; set; }
     }
 }

--- a/src/TumblThree/TumblThree.Applications/Services/ShellService.cs
+++ b/src/TumblThree/TumblThree.Applications/Services/ShellService.cs
@@ -25,6 +25,7 @@ namespace TumblThree.Applications.Services
         private bool isClosingEventInitialized;
         private event CancelEventHandler closing;
         private ClipboardMonitor clipboardMonitor;
+        private OAuthManager oauthManager;
 
         [ImportingConstructor]
         public ShellService(Lazy<IShellView> shellView)
@@ -33,6 +34,7 @@ namespace TumblThree.Applications.Services
             this.tasksToCompleteBeforeShutdown = new List<Task>();
             this.applicationBusyContext = new List<ApplicationBusyContext>();
             this.clipboardMonitor = new ClipboardMonitor();
+            this.oauthManager = new OAuthManager();
         }
 
         public AppSettings Settings { get; set; }
@@ -150,10 +152,24 @@ namespace TumblThree.Applications.Services
             OnClosing(e);
         }
 
+        public void InitializeOAuthManager()
+        {
+            OAuthManager["consumer_key"] = Settings.ApiKey;
+            OAuthManager["consumer_secret"] = Settings.SecretKey;
+            OAuthManager["token"] = Settings.OAuthToken;
+            OAuthManager["token_secret"] = Settings.OAuthTokenSecret;
+        }
+
         public ClipboardMonitor ClipboardMonitor
         {
             get { return clipboardMonitor; }
             set { SetProperty(ref clipboardMonitor, value); }
+        }
+
+        public OAuthManager OAuthManager
+        {
+            get { return oauthManager; }
+            set { SetProperty(ref oauthManager, value); }
         }
     }
 }

--- a/src/TumblThree/TumblThree.Applications/TumblThree.Applications.csproj
+++ b/src/TumblThree/TumblThree.Applications/TumblThree.Applications.csproj
@@ -78,6 +78,7 @@
     <Compile Include="DataModels\TumblrPost.cs" />
     <Compile Include="Data\StringListConverter.cs" />
     <Compile Include="Data\SupportedFileTypes.cs" />
+    <Compile Include="OAuth.cs" />
     <Compile Include="PauseTokenSource.cs" />
     <Compile Include="Properties\QueueSettings.cs" />
     <Compile Include="DataModels\FolderBrowserDataModel.cs" />

--- a/src/TumblThree/TumblThree.Applications/TumblThree.Applications.csproj
+++ b/src/TumblThree/TumblThree.Applications/TumblThree.Applications.csproj
@@ -51,6 +51,8 @@
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core" />
     <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Web" />
+    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xaml" />
     <Reference Include="System.XML" />
@@ -72,6 +74,8 @@
     <Compile Include="Controllers\ModuleController.cs" />
     <Compile Include="Controllers\QueueController.cs" />
     <Compile Include="DataModels\DownloadProgress.cs" />
+    <Compile Include="DataModels\TumblrJson.cs" />
+    <Compile Include="DataModels\TumblrPost.cs" />
     <Compile Include="Data\StringListConverter.cs" />
     <Compile Include="Data\SupportedFileTypes.cs" />
     <Compile Include="PauseTokenSource.cs" />

--- a/src/TumblThree/TumblThree.Applications/TumblThree.Applications.csproj
+++ b/src/TumblThree/TumblThree.Applications/TumblThree.Applications.csproj
@@ -103,12 +103,14 @@
     <Compile Include="ViewModels\DetailsViewModel.cs" />
     <Compile Include="ViewModels\ManagerViewModel.cs" />
     <Compile Include="ViewModels\QueueViewModel.cs" />
+    <Compile Include="ViewModels\AuthenticateViewModel.cs" />
     <Compile Include="ViewModels\SettingsViewModel.cs" />
     <Compile Include="ViewModels\ShellViewModel.cs" />
     <Compile Include="Views\IAboutView.cs" />
     <Compile Include="Views\IDetailsView.cs" />
     <Compile Include="Views\IManagerView.cs" />
     <Compile Include="Views\IQueueView.cs" />
+    <Compile Include="Views\IAuthenticateView.cs" />
     <Compile Include="Views\ISettingsView.cs" />
     <Compile Include="Views\IShellView.cs" />
   </ItemGroup>

--- a/src/TumblThree/TumblThree.Applications/ViewModels/AuthenticateViewModel.cs
+++ b/src/TumblThree/TumblThree.Applications/ViewModels/AuthenticateViewModel.cs
@@ -20,12 +20,18 @@ namespace TumblThree.Applications.ViewModels
     public class AuthenticateViewModel : ViewModel<IAuthenticateView>
     {
 
+        private string oauthCallbackUrl;
+
         [ImportingConstructor]
-        public AuthenticateViewModel(IAuthenticateView view)
+        public AuthenticateViewModel(IAuthenticateView view, IShellService shellService)
             : base(view)
         {
             view.Closed += ViewClosed;
+            ShellService = shellService;
+            this.oauthCallbackUrl = shellService.Settings.OAuthCallbackUrl;
         }
+
+        public IShellService ShellService { get; }
 
         //public IView View { get; set; }
 
@@ -46,6 +52,12 @@ namespace TumblThree.Applications.ViewModels
         public string GetUrl()
         {
             return ViewCore.GetUrl();
+        }
+
+        public string OAuthCallbackUrl
+        {
+            get { return oauthCallbackUrl; }
+            set { SetProperty(ref oauthCallbackUrl, value); }
         }
     }
 }

--- a/src/TumblThree/TumblThree.Applications/ViewModels/AuthenticateViewModel.cs
+++ b/src/TumblThree/TumblThree.Applications/ViewModels/AuthenticateViewModel.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Waf.Applications;
+using TumblThree.Applications.Views;
+using TumblThree.Domain;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.ComponentModel.Composition;
+using TumblThree.Applications.Services;
+using TumblThree.Applications.Properties;
+using TumblThree.Applications.DataModels;
+using System.ComponentModel;
+using System.IO;
+using System.Windows.Input;
+
+namespace TumblThree.Applications.ViewModels
+{
+    [Export]
+    public class AuthenticateViewModel : ViewModel<IAuthenticateView>
+    {
+
+        [ImportingConstructor]
+        public AuthenticateViewModel(IAuthenticateView view)
+            : base(view)
+        {
+            view.Closed += ViewClosed;
+        }
+
+        //public IView View { get; set; }
+
+        public void ShowDialog(object owner)
+        {
+            ViewCore.ShowDialog(owner);
+        }
+
+        private void ViewClosed(object sender, EventArgs e)
+        {
+        }
+
+        public void AddUrl(string url)
+        {
+            ViewCore.AddUrl(url);
+        }
+
+        public string GetUrl()
+        {
+            return ViewCore.GetUrl();
+        }
+    }
+}

--- a/src/TumblThree/TumblThree.Applications/ViewModels/ManagerViewModel.cs
+++ b/src/TumblThree/TumblThree.Applications/ViewModels/ManagerViewModel.cs
@@ -6,7 +6,7 @@ using System.Waf.Applications;
 using System.Windows.Input;
 using TumblThree.Applications.Services;
 using TumblThree.Applications.Views;
-using TumblThree.Applications.DataModels;
+using DataModels = TumblThree.Applications.DataModels;
 using TumblThree.Domain;
 using System.Linq;
 using System.Text;

--- a/src/TumblThree/TumblThree.Applications/ViewModels/SettingsViewModel.cs
+++ b/src/TumblThree/TumblThree.Applications/ViewModels/SettingsViewModel.cs
@@ -31,6 +31,7 @@ namespace TumblThree.Applications.ViewModels
         private string secretKey;
         private string oauthToken;
         private string oauthTokenSecret;
+        private string oauthCallbackUrl;
         private int parallelImages;
         private int parallelBlogs;
         private int imageSize;
@@ -96,6 +97,12 @@ namespace TumblThree.Applications.ViewModels
         {
             get { return secretKey; }
             set { SetProperty(ref secretKey, value); }
+        }
+
+        public string OAuthCallbackUrl
+        {
+            get { return oauthCallbackUrl; }
+            set { SetProperty(ref oauthCallbackUrl, value); }
         }
 
         public string DownloadLocation
@@ -184,6 +191,7 @@ namespace TumblThree.Applications.ViewModels
                 SecretKey = settings.SecretKey;
                 OAuthToken = settings.OAuthToken;
                 OAuthTokenSecret = settings.OAuthTokenSecret;
+                OAuthCallbackUrl = settings.OAuthCallbackUrl;
                 DownloadLocation = settings.DownloadLocation;
                 ParallelImages = settings.ParallelImages;
                 ParallelBlogs = settings.ParallelBlogs;
@@ -201,7 +209,8 @@ namespace TumblThree.Applications.ViewModels
             else
             {
                 ApiKey = "lICmmi2UfTdai1aVEfrMMoKidUfIMDV1pXlfiVdqhLmQgTNI9D";
-                SecretKey = "BB2JvuSMfa0";
+                SecretKey = "BB2Mfa0";
+                OAuthCallbackUrl = @"https://github.com/johanneszab/TumblThree";
                 OAuthToken = string.Empty;
                 OAuthTokenSecret = string.Empty;
                 DownloadLocation = ".\\Blogs";
@@ -243,6 +252,7 @@ namespace TumblThree.Applications.ViewModels
             settings.SecretKey = SecretKey;
             settings.OAuthToken = OAuthToken;
             settings.OAuthTokenSecret = OAuthTokenSecret;
+            settings.OAuthCallbackUrl = OAuthCallbackUrl;
         }
 
         public void Load()
@@ -269,7 +279,7 @@ namespace TumblThree.Applications.ViewModels
             ShellService.OAuthManager["consumer_key"] = ApiKey;
             ShellService.OAuthManager["consumer_secret"] = SecretKey;
             OAuthResponse requestToken =
-                ShellService.OAuthManager.AcquireRequestToken(settings.RequestTokenUrl, "GET");
+                ShellService.OAuthManager.AcquireRequestToken(settings.RequestTokenUrl, "POST");
             var url = settings.AuthorizeUrl + @"?oauth_token=" + ShellService.OAuthManager["token"];
 
             var authenticateViewModel = authenticateViewModelFactory.CreateExport().Value;
@@ -281,7 +291,7 @@ namespace TumblThree.Applications.ViewModels
             string oauthVerifer = regex.Match(oauthTokenUrl).Groups[1].ToString();
 
             OAuthResponse accessToken =
-                ShellService.OAuthManager.AcquireAccessToken(settings.AccessTokenUrl, "GET", oauthVerifer);
+                ShellService.OAuthManager.AcquireAccessToken(settings.AccessTokenUrl, "POST", oauthVerifer);
 
             regex = new Regex("oauth_token=(.*)&oauth_token_secret");
             OAuthToken = regex.Match(accessToken.AllText).Groups[1].ToString();
@@ -291,6 +301,9 @@ namespace TumblThree.Applications.ViewModels
 
             ShellService.OAuthManager["token"] = OAuthToken;
             ShellService.OAuthManager["token_secret"] = OAuthTokenSecret;
+
+            //OAuthToken = ShellService.OAuthManager["token"];
+            //OAuthTokenSecret = ShellService.OAuthManager["token_secret"];
         }
 
         private void FolderBrowserPropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/src/TumblThree/TumblThree.Applications/ViewModels/SettingsViewModel.cs
+++ b/src/TumblThree/TumblThree.Applications/ViewModels/SettingsViewModel.cs
@@ -209,8 +209,8 @@ namespace TumblThree.Applications.ViewModels
             else
             {
                 ApiKey = "lICmmi2UfTdai1aVEfrMMoKidUfIMDV1pXlfiVdqhLmQgTNI9D";
-                SecretKey = "BB2Mfa0";
-                OAuthCallbackUrl = @"https://github.com/johanneszab/TumblThree";
+                SecretKey = "BB2JMMfa0";
+                OAuthCallbackUrl = @"http://www.tumblr.com/tumblthree";
                 OAuthToken = string.Empty;
                 OAuthTokenSecret = string.Empty;
                 DownloadLocation = ".\\Blogs";
@@ -301,9 +301,6 @@ namespace TumblThree.Applications.ViewModels
 
             ShellService.OAuthManager["token"] = OAuthToken;
             ShellService.OAuthManager["token_secret"] = OAuthTokenSecret;
-
-            //OAuthToken = ShellService.OAuthManager["token"];
-            //OAuthTokenSecret = ShellService.OAuthManager["token_secret"];
         }
 
         private void FolderBrowserPropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/src/TumblThree/TumblThree.Applications/ViewModels/SettingsViewModel.cs
+++ b/src/TumblThree/TumblThree.Applications/ViewModels/SettingsViewModel.cs
@@ -23,6 +23,7 @@ namespace TumblThree.Applications.ViewModels
         private readonly AppSettings settings;
         private readonly FolderBrowserDataModel folderBrowser;
         private DelegateCommand displayFolderBrowserCommand;
+        private DelegateCommand authenticateCommand;
         private string downloadLocation;
         private int parallelImages;
         private int parallelBlogs;
@@ -47,6 +48,7 @@ namespace TumblThree.Applications.ViewModels
             settings = ShellService.Settings;
             this.folderBrowser = new FolderBrowserDataModel();
             this.displayFolderBrowserCommand = new DelegateCommand(DisplayFolderBrowser);
+            this.authenticateCommand = new DelegateCommand(Authenticate);
 
             Load();
             view.Closed += ViewClosed;
@@ -205,6 +207,8 @@ namespace TumblThree.Applications.ViewModels
 
         public ICommand DisplayFolderBrowserCommand { get { return displayFolderBrowserCommand; } }
 
+        public ICommand AuthenticateCommand { get { return authenticateCommand; } }
+
         private void DisplayFolderBrowser()
         {
             System.Windows.Forms.FolderBrowserDialog dialog = new System.Windows.Forms.FolderBrowserDialog();
@@ -213,6 +217,23 @@ namespace TumblThree.Applications.ViewModels
             {
                 DownloadLocation = dialog.SelectedPath;
             }
+        }
+
+        private void Authenticate()
+        {
+            OAuthManager oauthManager = new OAuthManager();
+            oauthManager["consumer_key"] = settings.ApiKey;
+            oauthManager["consumer_secret"] = settings.SecretKey;
+            //oauthManager["callback"] = Uri.EscapeUriString(shellService.Settings.OAuthCallback);
+            OAuthResponse requestToken =
+                oauthManager.AcquireRequestToken("https://www.tumblr.com/oauth/request_token", "GET");
+            // Start the browser to get the access token from the user
+            var url = @"https://www.tumblr.com/oauth/authorize?oauth_token=" + oauthManager["token"];
+
+            System.Diagnostics.Process.Start(url);
+
+            //System.Windows.Controls.WebBrowser browser = new System.Windows.Controls.WebBrowser();
+            //browser.Source = new Uri(url);
         }
 
         private void FolderBrowserPropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/src/TumblThree/TumblThree.Applications/Views/IAuthenticateView.cs
+++ b/src/TumblThree/TumblThree.Applications/Views/IAuthenticateView.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Waf.Applications;
+
+namespace TumblThree.Applications.Views
+{
+    public interface IAuthenticateView : IView
+    {
+        void ShowDialog(object owner);
+
+        event EventHandler Closed;
+
+        void AddUrl(string url);
+
+        string GetUrl();
+    }
+}

--- a/src/TumblThree/TumblThree.Domain/Models/TumblrBlog.cs
+++ b/src/TumblThree/TumblThree.Domain/Models/TumblrBlog.cs
@@ -10,14 +10,14 @@ namespace TumblThree.Domain.Models
     public class TumblrBlog : Blog
     {
         private string description;
-        private string text;
+        private string title;
         private uint progress;
         private string tags;
 
         public TumblrBlog()
         {
             this.description = null;
-            this.text = null;
+            this.title = null;
             this.progress = 0;
             this.tags = null;
         }
@@ -26,7 +26,7 @@ namespace TumblThree.Domain.Models
         {
             this.description = null;
             this.Url = url;
-            this.text = null;
+            this.title = null;
             this.progress = 0;
             this.tags = null;
         }
@@ -37,10 +37,10 @@ namespace TumblThree.Domain.Models
             set { SetProperty(ref description, value); }
         }
 
-        public string Text
+        public string Title
         {
-            get { return text; }
-            set { SetProperty(ref text, value); }
+            get { return title; }
+            set { SetProperty(ref title, value); }
         }
 
         public uint Progress

--- a/src/TumblThree/TumblThree.Presentation/DesignData/MockShellService.cs
+++ b/src/TumblThree/TumblThree.Presentation/DesignData/MockShellService.cs
@@ -62,6 +62,7 @@ namespace TumblThree.Presentation.DesignData
 
         public ClipboardMonitor ClipboardMonitor { get; set; }
 
+        public OAuthManager OAuthManager { get; set; }
 
         public IDisposable SetApplicationBusy()
         {

--- a/src/TumblThree/TumblThree.Presentation/Properties/Resources.Designer.cs
+++ b/src/TumblThree/TumblThree.Presentation/Properties/Resources.Designer.cs
@@ -88,6 +88,15 @@ namespace TumblThree.Presentation.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Authenticate.
+        /// </summary>
+        public static string Authenticate {
+            get {
+                return ResourceManager.GetString("Authenticate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Enter URL:.
         /// </summary>
         public static string BlogUrl {

--- a/src/TumblThree/TumblThree.Presentation/Properties/Resources.de.resx
+++ b/src/TumblThree/TumblThree.Presentation/Properties/Resources.de.resx
@@ -312,4 +312,7 @@
   <data name="Website" xml:space="preserve">
     <value>Webseite</value>
   </data>
+  <data name="Authenticate" xml:space="preserve">
+    <value>Authentifizieren</value>
+  </data>
 </root>

--- a/src/TumblThree/TumblThree.Presentation/Properties/Resources.resx
+++ b/src/TumblThree/TumblThree.Presentation/Properties/Resources.resx
@@ -312,4 +312,7 @@
   <data name="VideoSize" xml:space="preserve">
     <value>Video Size</value>
   </data>
+  <data name="Authenticate" xml:space="preserve">
+    <value>Authenticate</value>
+  </data>
 </root>

--- a/src/TumblThree/TumblThree.Presentation/TumblThree.Presentation.csproj
+++ b/src/TumblThree/TumblThree.Presentation/TumblThree.Presentation.csproj
@@ -122,6 +122,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="Views\AuthenticateView.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
     <Page Include="Views\SettingsView.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -182,6 +186,9 @@
     </Compile>
     <Compile Include="Views\QueueView.xaml.cs">
       <DependentUpon>QueueView.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Views\AuthenticateView.xaml.cs">
+      <DependentUpon>AuthenticateView.xaml</DependentUpon>
     </Compile>
     <Compile Include="Views\SettingsView.xaml.cs">
       <DependentUpon>SettingsView.xaml</DependentUpon>

--- a/src/TumblThree/TumblThree.Presentation/Views/AboutView.xaml
+++ b/src/TumblThree/TumblThree.Presentation/Views/AboutView.xaml
@@ -15,7 +15,7 @@
         </Border>
 
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
-            <ContentControl Content="{StaticResource TumblThreeXamlIcon}" Width="256" Margin="22,11,22,0"/>
+            <Image Source="../Resources/Images/Tumblr.png"  Width="256" Margin="22,11,22,0"/>
 
             <Grid Margin="0,0,22,11" VerticalAlignment="Center">
                 <Grid.Resources>

--- a/src/TumblThree/TumblThree.Presentation/Views/AuthenticateView.xaml
+++ b/src/TumblThree/TumblThree.Presentation/Views/AuthenticateView.xaml
@@ -1,0 +1,23 @@
+﻿<Window x:Class="TumblThree.Presentation.Views.AuthenticateView"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:p="clr-namespace:TumblThree.Presentation.Properties"
+        xmlns:dd="clr-namespace:TumblThree.Presentation.DesignData"
+        xmlns:ctrl="clr-namespace:TumblThree.Presentation.Controls"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"  
+        xmlns:vm="clr-namespace:TumblThree.Applications.ViewModels;assembly=TumblThree.Applications"
+        mc:Ignorable="d" Title="AuthenticateView" Height="540" Width="600"
+        d:DataContext="{d:DesignInstance vm:AuthenticateViewModel}">
+
+
+    <Grid Margin="0" VerticalAlignment="Stretch" Grid.Row="0">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*"/>
+        </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+        <WebBrowser x:Name="browser" Grid.Column="0" Grid.Row="0" HorizontalAlignment="Stretch" Margin="10,10,10,10" VerticalAlignment="Top" Width="Auto" Height="Auto"/>
+    </Grid>
+</Window>

--- a/src/TumblThree/TumblThree.Presentation/Views/AuthenticateView.xaml.cs
+++ b/src/TumblThree/TumblThree.Presentation/Views/AuthenticateView.xaml.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Waf.Applications;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Shapes;
+using TumblThree.Applications.ViewModels;
+using TumblThree.Applications.Views;
+
+namespace TumblThree.Presentation.Views
+{
+    /// <summary>
+    /// Interaction logic for SettingsView.xaml
+    /// </summary>
+   [Export(typeof(IAuthenticateView)), PartCreationPolicy(CreationPolicy.NonShared)]
+    public partial class AuthenticateView : Window, IAuthenticateView
+    {
+
+        private readonly Lazy<AuthenticateViewModel> viewModel;
+
+        public AuthenticateView()
+        {
+            InitializeComponent();
+            this.viewModel = new Lazy<AuthenticateViewModel>(() => ViewHelper.GetViewModel<AuthenticateViewModel>(this));
+        }
+
+        private AuthenticateViewModel ViewModel { get { return viewModel.Value; } }
+
+        public void ShowDialog(object owner)
+        {
+            Owner = owner as Window;
+            ShowDialog();
+        }
+
+        private void closeWindow(object sender, RoutedEventArgs e)
+        {
+            this.Close();
+        }
+
+        public void AddUrl(string url)
+        {
+            browser.Source = new Uri(url);
+        }
+
+        public string GetUrl()
+        {
+            return browser.Source.ToString();
+        }
+    }
+}

--- a/src/TumblThree/TumblThree.Presentation/Views/AuthenticateView.xaml.cs
+++ b/src/TumblThree/TumblThree.Presentation/Views/AuthenticateView.xaml.cs
@@ -31,6 +31,28 @@ namespace TumblThree.Presentation.Views
         {
             InitializeComponent();
             this.viewModel = new Lazy<AuthenticateViewModel>(() => ViewHelper.GetViewModel<AuthenticateViewModel>(this));
+
+            browser.Navigated += Browser_Navigated;
+        }
+
+        private void Browser_Navigated(object sender, System.Windows.Navigation.NavigationEventArgs e)
+        {
+            try
+            {
+                WebBrowser wb = (WebBrowser)sender;
+                if (wb.Source.ToString().Contains("tumblthree"))
+                {
+                    this.Close();
+                }
+            }
+            catch
+            {
+            }
+        }
+
+        private void Browser_Navigating(object sender, System.Windows.Navigation.NavigatingCancelEventArgs e)
+        {
+
         }
 
         private AuthenticateViewModel ViewModel { get { return viewModel.Value; } }

--- a/src/TumblThree/TumblThree.Presentation/Views/AuthenticateView.xaml.cs
+++ b/src/TumblThree/TumblThree.Presentation/Views/AuthenticateView.xaml.cs
@@ -40,7 +40,7 @@ namespace TumblThree.Presentation.Views
             try
             {
                 WebBrowser wb = (WebBrowser)sender;
-                if (wb.Source.ToString().Contains("tumblthree"))
+                if (wb.Source.ToString().Contains(ViewModel.OAuthCallbackUrl))
                 {
                     this.Close();
                 }

--- a/src/TumblThree/TumblThree.Presentation/Views/SettingsView.xaml
+++ b/src/TumblThree/TumblThree.Presentation/Views/SettingsView.xaml
@@ -87,6 +87,7 @@
             <CheckBox x:Name="checkBoxRemoveIndex" Content="{x:Static p:Resources.RemoveIndex}" IsChecked="{Binding RemoveIndexAfterCrawl, Mode=TwoWay}" Grid.Column="0" Grid.Row="5" HorizontalAlignment="Left" Margin="10" VerticalAlignment="Top"/>
         </Grid>
         <Grid Height="Auto" Margin="0" VerticalAlignment="Bottom" Grid.Row="5">
+            <Button x:Name="buttonAuthenticate" Height="Auto" Content="{x:Static p:Resources.Authenticate}" Command="{Binding AuthenticateCommand}" Margin="10" VerticalAlignment="Bottom" HorizontalAlignment="Left" Width="75"/>
             <Button Height="Auto" Content="Save" Margin="10" VerticalAlignment="Bottom" HorizontalAlignment="Right" Width="75" Click="closeWindow"/>
         </Grid>
     </Grid>


### PR DESCRIPTION
Transition to the Tumblr API version 2 and authentication using the oauth 1.0a protocol.

The authentication allows the download of private blogs. Using the json data from the newer version 2 api its now possible to implement the download of text, ask, faq, chat, answer, audio posts. Also saved files can be created with the file date of the creation dates of the posts. The id of a post could be used to implement a more robust resume function instead of comparing the local database to all remote posts.