### PR TITLE
Update LoliSafeParser.cs

### DIFF
--- a/src/TumblThree/TumblThree.Applications/Parser/LoliSafeParser.cs
+++ b/src/TumblThree/TumblThree.Applications/Parser/LoliSafeParser.cs
@@ -9,7 +9,7 @@ namespace TumblThree.Applications.Parser
 	{
 		public Regex GetLoliSafeUrlRegex()
 		{
-			return new Regex("(http[A-Za-z0-9_/:.]*loli.temel.me/(.*))");
+			return new Regex("(http[A-Za-z0-9_/:.]*(loli.temel.me|3dx.pw)/(.*))");
 		}
 
 		public string CreateLoliSafeUrl(string id, string detectedUrl, LoliSafeTypes type)
@@ -18,10 +18,10 @@ namespace TumblThree.Applications.Parser
 			switch ( type)
 			{
 				case LoliSafeTypes.Mp4:
-					url = @"https://loli.temel.me/" +  id + ".mp4";
+					url = @"https://3dx.pw/" +  id + ".mp4";
 					break;
 				case LoliSafeTypes.Webm:
-					url = @"https://loli.temel.me/" +  id + ".webm";
+					url = @"https://3dx.pw/" +  id + ".webm";
 					break;
 				case LoliSafeTypes.Any:
 					url = detectedUrl;


### PR DESCRIPTION
loli.temel.me moved to 3dx.pw
Old urls still work since a redirect is in place, but parser needed to be updated to also detect 3dx.pw urls.